### PR TITLE
fix(layout): move ThemeSwitcherProvider inside body tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import { Footer, NavBar } from "@/components";
-import { ThemeSwitcherProvider } from "@/hooks/useThemeSwitcher";
 import type { Metadata } from "next";
 import { Montserrat } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const montserrat = Montserrat({
   subsets: ["latin"],
@@ -21,14 +21,14 @@ export default function RootLayout({
 }>) {
 
   return (
-    <ThemeSwitcherProvider>
-      <html lang="en">
-        <body className={`${montserrat.variable} font-mont bg-light dark:bg-dark w-full min-h-screen`}>
+    <html lang="en">
+      <body className={`${montserrat.variable} font-mont bg-light dark:bg-dark w-full min-h-screen`}>
+        <Providers>
           <NavBar />
           {children}
           <Footer />
-        </body>
-      </html>
-    </ThemeSwitcherProvider>
+        </Providers>
+      </body>
+    </html>
   );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ThemeSwitcherProvider } from '@/hooks/useThemeSwitcher'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+    return <ThemeSwitcherProvider>{children}</ThemeSwitcherProvider>
+}


### PR DESCRIPTION
Fixed #1 - ThemeSwitcherProvider incorrectly wrapping html/body

## Changes
- Created new client component `Providers.tsx`
- Moved ThemeSwitcherProvider inside body tag
- Updated layout.tsx to use new Providers component

## Testing
- [x] Theme switcher still works
- [x] No hydration errors in console
- [x] Works in Chrome, Firefox, Safari
- [x] Mobile responsive
- [x] Builds successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the provider architecture to improve code organization and maintainability of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->