### PR TITLE
security: prevent reverse tabnabbing by adding rel=noopener noreferrer

### DIFF
--- a/src/components/home/CTA.tsx
+++ b/src/components/home/CTA.tsx
@@ -45,6 +45,7 @@ export const CTA = () => {
                             <Link
                                 href="/Junaid's Resume.pdf"
                                 target={"_blank"}
+                                rel="noopener noreferrer"
                                 className="flex items-center bg-dark text-light md:p-2.5 md:px-6 
                                 rounded-lg md:text-lg font-semibold
                                 hover:bg-light hover:text-dark
@@ -59,6 +60,7 @@ export const CTA = () => {
                             <Link
                                 href="mailto:junaid.ali101452@gmail.com"
                                 target={"_blank"}
+                                rel="noopener noreferrer"
                                 className="ml-4 md:text-lg font-medium underline capitalize text-dark dark:text-light text-base"
                             >
                                 Contact

--- a/src/components/home/projects/FeaturedProjects.tsx
+++ b/src/components/home/projects/FeaturedProjects.tsx
@@ -16,6 +16,7 @@ const FeaturedProjects = ({ title, summary, img, link, github, tech, index }: an
             <Link
                 href={link}
                 target="_blank"
+                rel="noopener noreferrer"
                 className="lg:w-1/2 overflow-hidden rounded-lg cursor-pointer w-full"
             >
                 <FramerImage
@@ -35,6 +36,7 @@ const FeaturedProjects = ({ title, summary, img, link, github, tech, index }: an
                 <Link
                     href={link}
                     target="_blank"
+                    rel="noopener noreferrer"
                     className="hover:underline underline-offset-2"
                 >
                     <h2 className="w-full my-2 sm:text-4xl font-bold text-left dark:text-light text-sm">
@@ -59,6 +61,7 @@ const FeaturedProjects = ({ title, summary, img, link, github, tech, index }: an
                     <FramerLink
                         href={github}
                         target="_blank"
+                        rel="noopener noreferrer"
                         whileHover={{ y: -2 }}
                         whileTap={{ scale: 0.9 }}
                     >
@@ -72,6 +75,7 @@ const FeaturedProjects = ({ title, summary, img, link, github, tech, index }: an
                     <FramerLink
                         href={link}
                         target="_blank"
+                        rel="noopener noreferrer"
                         whileHover={{ y: -2 }}
                         whileTap={{ scale: 0.9 }}
                         className="font-medium dark:text-light text-sm hover:text-[#1B9CFC]

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -16,17 +16,11 @@ export const Footer = () => {
                         href="https://www.instagram.com/junaid.ali1014/"
                         className="underline underline-offset-2"
                         target={"_blank"}
+                        rel="noopener noreferrer"
                     >
                         Junaid Ali Bhatti
                     </Link>
                 </div>
-                {/* <Link
-                    href="https://www.instagram.com/junaid.ali1014/"
-                    className="underline underline-offset-2"
-                    target={"_blank"}
-                >
-                    Say hello
-                </Link> */}
             </Layout>
         </footer>
     );

--- a/src/components/ui/NavBar/NavBar.tsx
+++ b/src/components/ui/NavBar/NavBar.tsx
@@ -61,6 +61,7 @@ export const NavBar = () => {
                             key={i}
                             href={href}
                             target={"_blank"}
+                            rel="noopener noreferrer"
                             whileHover={{ y: -2 }}
                             whileTap={{ scale: 0.9 }}
                             className={`w-6 mx-3 ${href == "https://www.linkedin.com/in/junaid-ali-bhatti-34b680243/" ? "bg-light" : ""} `}
@@ -110,6 +111,7 @@ export const NavBar = () => {
                                 key={i}
                                 href={href}
                                 target={"_blank"}
+                                rel="noopener noreferrer"
                                 whileHover={{ y: -2 }}
                                 whileTap={{ scale: 0.9 }}
                                 className={`w-6 sm:mr-3 mx-1 ${href == "https://www.linkedin.com/in/junaid-ali-bhatti-34b680243/" ? "bg-light" : ""} 


### PR DESCRIPTION
Fixed #7 
## What changed?
Added `rel="noopener noreferrer"` to all external links with `target="_blank"` in:
- FeaturedProjects.tsx
- Footer.tsx
- NavBar.tsx

## Why?
External links opening in new tabs without rel="noopener noreferrer" are vulnerable to reverse tabnabbing attacks where the external site can control the original page.

## Files changed:
- [x] src/components/home/projects/FeaturedProjects.tsx
- [x] src/components/ui/Footer.tsx
- [x] src/components/ui/NavBar/NavBar.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied standardized link attributes across the application including navigation menus (desktop and mobile), call-to-action sections, featured projects, and footer social links for consistent handling when opening external content in new tabs.
  * Removed previously commented-out code from the footer component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->